### PR TITLE
feat: Obsidian 1.0.0 Support

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,2 +1,3 @@
+- 2022-10-15 Obsidian 1.0.0 support
 - 2022-09-25 Stable release
 - 2022-09-25 Initial commit

--- a/manifest.json
+++ b/manifest.json
@@ -2,8 +2,8 @@
   "id": "obsidian-theme-toggler",
   "name": "Theme Toggler",
   "description": "Toggle the theme in Obsidian's panels.",
-  "version": "1.0.0",
-  "minAppVersion": "0.15.9",
+  "version": "1.0.1",
+  "minAppVersion": "1.0.0",
   "isDesktopOnly": true,
   "author": "larsmagnus",
   "authorUrl": "https://larsmagnus.co"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "obsidian-theme-toggler",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"description": "Toggle the theme in Obsidian's panels.",
 	"main": "main.js",
 	"scripts": {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -5,17 +5,27 @@ import { PluginThemesEnum } from './PluginThemesEnum'
 export const PLUGIN_ID = 'theme-toggle'
 export const PLUGIN_CLASS_NAME = `${PLUGIN_ID}-button`
 
+/**
+ * All the available color themes
+ */
 export const PLUGIN_MODES = [
 	null,
 	PluginThemesEnum.Light,
 	PluginThemesEnum.Dark,
 ]
 
+/**
+ * Base settings for the button that's added to the panel
+ */
+export const BUTTON_SETTINGS = {
+	id: PLUGIN_ID,
+	icon: 'any-key',
+	name: getToggleThemeLabel(),
+}
+
+/**
+ * All persisted settings
+ */
 export const DEFAULT_SETTINGS: ThemeToggleSettings = {
-	buttonSettings: {
-		id: PLUGIN_ID,
-		icon: 'any-key',
-		name: getToggleThemeLabel(),
-	},
 	leafSettings: [],
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,7 +21,6 @@ export interface ButtonBase {
 export type Themes = PluginThemeTypes | null
 
 export interface ThemeToggleSettings {
-	buttonSettings: ButtonBase
 	leafSettings: LeafSettings[]
 }
 

--- a/styles.css
+++ b/styles.css
@@ -1,3 +1,14 @@
+/**
+* v1.0.0 changed background and text color styling, so set them explicitly 
+*/
+.theme-light, .theme-dark {
+  --background-primary: var(--color-base-00);
+  --background-primary-alt: var(--color-base-10);
+  --background-secondary: var(--color-base-20);
+  --code-background: var(--background-primary-alt);
+  --text-normal: var(--color-base-100);
+}
+
 [class^="workspace-"]:is(.theme-light, .theme-dark) {
   color: var(--text-normal);
 }


### PR DESCRIPTION
## Description of the Change
- Move button settings to a constant
- Simplifies the event listener for panel button clicks
- Explicitly set the custom CSS variables for text colours as they've been moved for Obsidian 1.0.0
- Adds more comments 
- Only support Obsidian 1.0.0 and up
- Cleans up unused ´getAppTheme´

## Checklist
- [x] Used the provided eslint configuration, [as explained in the Readme](README.md#Contribute).
- [ ] Did *not* use prettier.
- [x] Used expressive variable names.
- [x] Code is commented well.
